### PR TITLE
Quill takes value parameter

### DIFF
--- a/lib/quill/rails/templates/template.html.erb
+++ b/lib/quill/rails/templates/template.html.erb
@@ -110,8 +110,7 @@
       <span title="Link" class="sc-format-button sc-link"></span>
     </span>
   </div>
-  <div id="full-editor" class="editor">
-  </div>
+  <div id="full-editor" class="editor"><%= @value %></div>
   <input type='hidden' name='<%= @input_name %>' id='<%= @input_id %>' value=''/>
 
   <script type='text/javascript'>

--- a/lib/quill/rails/view_helpers.rb
+++ b/lib/quill/rails/view_helpers.rb
@@ -12,6 +12,7 @@ module Quill
         mod_options = { name: 'quill-value', id: 'quill-value' }.merge options
         @input_name = (name || mod_options[:name])
         @input_id   = (name || mod_options[:id])   
+        @value      = mod_options[:value].present? ? mod_options[:value] : ""
         ERB.new(File.read(File.join(source_root, 'template.html.erb'))).result(binding).html_safe
       end
     end


### PR DESCRIPTION
I needed the quill editor to be filled with a value.

This little modification allows it.
