### PR TITLE
Fix problems with loading quill.js defered

### DIFF
--- a/lib/quill/rails/templates/template.html.erb
+++ b/lib/quill/rails/templates/template.html.erb
@@ -120,23 +120,31 @@
 
   <script type='text/javascript'>
     (function() {
-      // Initialize editor with custom theme and modules
-      function copyToInput() {
-        document.getElementById('<%= @input_id %>').value = fullEditor.getHTML()
+      function initQuill() {
+        if (typeof Quill != 'undefined'){
+          // Initialize editor with custom theme and modules
+          function copyToInput() {
+            document.getElementById('<%= @input_id %>').value = fullEditor.getHTML()
+          }
+
+          var fullEditor = new Quill('#full-editor-<%= @input_id %>', {
+            modules: {
+              'toolbar': { container: '#full-toolbar-<%= @input_id %>' },
+              'link-tooltip': true
+            },
+            theme: 'snow'
+          });
+
+          fullEditor.on('text-change', function(delta, source) {
+            copyToInput()
+          });
+          copyToInput()
+        } else { 
+          setTimeout(initQuill, 50);
+        }        
       }
 
-      var fullEditor = new Quill('#full-editor-<%= @input_id %>', {
-        modules: {
-          'toolbar': { container: '#full-toolbar-<%= @input_id %>' },
-          'link-tooltip': true
-        },
-        theme: 'snow'
-      });
-
-      fullEditor.on('text-change', function(delta, source) {
-        copyToInput()
-      });
-      copyToInput()
+      initQuill();
     })()
   </script>
 </div>


### PR DESCRIPTION
I'm loading my javascripts with defer set to true:
    = javascript_include_tag 'application', 'data-turbolinks-track' => true, :defer => true
Which makes Quill undefinded at the time the js inside the template is executed.

This PR tries to fix it. 
